### PR TITLE
Correct spelling of "closuers"

### DIFF
--- a/_posts/2017-08-28-php.md
+++ b/_posts/2017-08-28-php.md
@@ -242,4 +242,4 @@ if (
 
 ## <a id="closures"></a> Closures
 
-We adhere to the [PSR-2 guidelines for closuers](http://www.php-fig.org/psr/psr-2/#6-closures) _except_ for the standards around spacing within parentheses.
+We adhere to the [PSR-2 guidelines for closures](http://www.php-fig.org/psr/psr-2/#6-closures) _except_ for the standards around spacing within parentheses.


### PR DESCRIPTION
Just correcting a typo.