### PR TITLE
Import/use baseline should be PSR-12, not PSR-2

### DIFF
--- a/docs/code-standards/php.md
+++ b/docs/code-standards/php.md
@@ -42,7 +42,7 @@ First and foremost, we make an attempt to adhere to the [WordPress PHP coding st
 
 ### Namespace and use declarations
 
-Where we are able to use Namespaces (tests, SaaS code, etc), we should adhere to the [PSR-2 standards for Namespaces and Use Declarations](http://www.php-fig.org/psr/psr-2/#3-namespace-and-use-declarations).
+Where we are able to use Namespaces (tests, SaaS code, etc), we should adhere to the [PSR-12 standards for Namespaces and Use Declarations](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements).
 
 ### Classes, properties, and methods
 


### PR DESCRIPTION
In working on a body of code that made use of `use function` statements, I noticed our own standards still reference PSR-2 in relation to `import` and `use` statements, however PSR-2 does not cover `use function` statements (which probably were not available when that standard was written).

I propose we move forward here to PSR-12 compliance.