### PR TITLE
Add note about template files and closing php tags.

### DIFF
--- a/docs/code-standards/php.md
+++ b/docs/code-standards/php.md
@@ -34,6 +34,7 @@ First and foremost, we make an attempt to adhere to the [WordPress PHP coding st
 
 * All PHP files MUST use the Unix LF (linefeed) line ending.
 * The closing `?>` tag MUST be omitted from files containing only or ending in PHP.
+  * Unless it is a views template file - as these have customization filters run immediately after them.
 
 ### Keywords and true/false/null
 


### PR DESCRIPTION
Our standards follow WP that closing tags are to be left off the end of a file.

This can create confusion/problems for customizers who don't realize it and utilize an end-of-template filter to add content.

This modifies the rule to insist on closing tags on views templates.